### PR TITLE
feat: SecurityContext에 인증객체 생성 및 JWT인증 예외 처리

### DIFF
--- a/dongmanee/src/main/java/com/dongmanee/domain/member/controller/MemberController.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/member/controller/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController {
 	private final MemberMapper memberMapper;
 
 	@PostMapping("/signup")
-	public ApiResponse UserSignUp(@Valid @RequestBody RequestSignup request) {
+	public ApiResponse<?> userSignUp(@Valid @RequestBody RequestSignup request) {
 		Member newMember = memberMapper.toEntity(request);
 		memberService.signup(newMember);
 		return ApiResponse.success("회원가입 성공");

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/config/SecurityConfig.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/config/SecurityConfig.java
@@ -51,8 +51,6 @@ public class SecurityConfig {
 			// HTTP 요청에 대한 인가 설정
 			.authorizeHttpRequests(
 				authorizedRequests -> authorizedRequests
-					.requestMatchers(new AntPathRequestMatcher("/test"))
-					.authenticated()
 					.requestMatchers(new AntPathRequestMatcher("/login"))
 					.permitAll() // 모든 요청에 대해서 인증 없이 허용
 					.requestMatchers(new AntPathRequestMatcher("/oauth2/**"))

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/config/SecurityConfig.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import com.dongmanee.domain.security.entrypoint.CustomAuthenticationEntryPoint;
 import com.dongmanee.domain.security.filter.CustomAuthenticationFilter;
 import com.dongmanee.domain.security.filter.JwtAuthenticationFilter;
+import com.dongmanee.domain.security.filter.JwtExceptionFilter;
 import com.dongmanee.domain.security.handler.CustomAccessDeniedHandler;
 import com.dongmanee.domain.security.handler.CustomAuthenticationSuccessHandler;
 import com.dongmanee.domain.security.provider.JwtProvider;
@@ -50,6 +51,8 @@ public class SecurityConfig {
 			// HTTP 요청에 대한 인가 설정
 			.authorizeHttpRequests(
 				authorizedRequests -> authorizedRequests
+					.requestMatchers(new AntPathRequestMatcher("/test"))
+					.authenticated()
 					.requestMatchers(new AntPathRequestMatcher("/login"))
 					.permitAll() // 모든 요청에 대해서 인증 없이 허용
 					.requestMatchers(new AntPathRequestMatcher("/oauth2/**"))
@@ -72,7 +75,8 @@ public class SecurityConfig {
 				.successHandler(customAuthenticationSuccessHandler))
 
 			// JWT 검증 및 인증
-			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/exception/CustomJwtException.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/exception/CustomJwtException.java
@@ -1,0 +1,22 @@
+package com.dongmanee.domain.security.exception;
+
+import org.springframework.http.HttpStatus;
+
+import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+
+@Getter
+public class CustomJwtException extends JwtException {
+	private final HttpStatus httpStatus;
+
+	public CustomJwtException(String message, HttpStatus httpStatus) {
+		super(message);
+		this.httpStatus = httpStatus;
+	}
+
+	public CustomJwtException(String message, HttpStatus httpStatus, Throwable cause) {
+		super(message, cause);
+		this.httpStatus = httpStatus;
+	}
+
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/exception/CustomJwtException.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/exception/CustomJwtException.java
@@ -7,16 +7,9 @@ import lombok.Getter;
 
 @Getter
 public class CustomJwtException extends JwtException {
-	private final HttpStatus httpStatus;
+	private final HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
 
-	public CustomJwtException(String message, HttpStatus httpStatus) {
-		super(message);
-		this.httpStatus = httpStatus;
+	public CustomJwtException() {
+		super("인증에 실패하였습니다.");
 	}
-
-	public CustomJwtException(String message, HttpStatus httpStatus, Throwable cause) {
-		super(message, cause);
-		this.httpStatus = httpStatus;
-	}
-
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/filter/JwtExceptionFilter.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,51 @@
+package com.dongmanee.domain.security.filter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.dongmanee.domain.security.exception.CustomJwtException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+	/**
+	 * JWT 관련 오류를 처리하기 위한 필터
+	 */
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+		throws ServletException, IOException {
+		try {
+			chain.doFilter(request, response);
+		} catch (CustomJwtException ex) {
+			// JwtAuthenticationFilter에서 발생한 예외 처리
+			setErrorResponse(request, response, ex);
+		}
+	}
+
+	private void setErrorResponse(HttpServletRequest req, HttpServletResponse res, CustomJwtException ex)
+		throws IOException {
+
+		res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+		final Map<String, Object> body = new HashMap<>();
+		body.put("status", ex.getHttpStatus().value());
+		body.put("error", ex.getMessage());
+		body.put("path", req.getServletPath());
+		body.put("timestamp", LocalDateTime.now().toString());
+		final ObjectMapper mapper = new ObjectMapper();
+		mapper.writeValue(res.getOutputStream(), body);
+		res.setStatus(ex.getHttpStatus().value());
+	}
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/provider/JwtProvider.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/provider/JwtProvider.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -91,16 +90,16 @@ public class JwtProvider {
 			return !claims.getBody().getExpiration().before(new Date());
 		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
 			log.error("잘못된 JWT 서명입니다.");
-			throw new CustomJwtException("잘못된 JWT 서명입니다.", HttpStatus.UNAUTHORIZED); //401
+			throw new CustomJwtException();
 		} catch (ExpiredJwtException e) {
 			log.error("만료된 JWT 토큰입니다.");
-			throw new CustomJwtException("만료된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED); //401
+			throw new CustomJwtException();
 		} catch (UnsupportedJwtException e) {
 			log.error("지원되지 않는 JWT 토큰입니다.");
-			throw new CustomJwtException("지원되지 않는 JWT 토큰입니다.", HttpStatus.BAD_REQUEST); //400
+			throw new CustomJwtException();
 		} catch (IllegalArgumentException e) {
 			log.error("JWT 토큰이 잘못되었습니다.");
-			throw new CustomJwtException("JWT 토큰이 잘못되었습니다.", HttpStatus.UNPROCESSABLE_ENTITY); //422
+			throw new CustomJwtException();
 		}
 	}
 

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/service/AuthService.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/service/AuthService.java
@@ -87,6 +87,23 @@ public class AuthService implements UserDetailsService, OAuth2UserService<OAuth2
 			attributes.getAttributes(), attributes.getNameAttributeKey());
 	}
 
+	/**
+	 * UserId 기반으로 데이터를 가져와 반환 -
+	 * JWTAuthenticationFilter 에서 사용
+	 *
+	 * @param userId
+	 * @return User
+	 */
+	public UserDetails loadUserById(Long userId) {
+		Member member = memberRepository.findById(userId).orElseThrow(UnAuthorizedException::new);
+
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority(member.getRole().getKey()));
+
+		// User: Spring Security에서 제공해주는 User 모델로 반환
+		return new User(member.getId().toString(), member.getPassword(), true, true, true, true, authorities);
+	}
+
 	private AuthProvider saveOrUpdate(String registrationId, OAuthAttributes attributes) {
 		Long externalProviderId = Long.valueOf(attributes.getAttributes().get("id").toString());
 		AuthProvider authProvider = authProviderRepository.findByAuthProviderAndExternalProviderId(registrationId,

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/service/AuthService.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/service/AuthService.java
@@ -87,23 +87,6 @@ public class AuthService implements UserDetailsService, OAuth2UserService<OAuth2
 			attributes.getAttributes(), attributes.getNameAttributeKey());
 	}
 
-	/**
-	 * UserId 기반으로 데이터를 가져와 반환 -
-	 * JWTAuthenticationFilter 에서 사용
-	 *
-	 * @param userId
-	 * @return User
-	 */
-	public UserDetails loadUserById(Long userId) {
-		Member member = memberRepository.findById(userId).orElseThrow(UnAuthorizedException::new);
-
-		List<GrantedAuthority> authorities = new ArrayList<>();
-		authorities.add(new SimpleGrantedAuthority(member.getRole().getKey()));
-
-		// User: Spring Security에서 제공해주는 User 모델로 반환
-		return new User(member.getId().toString(), member.getPassword(), true, true, true, true, authorities);
-	}
-
 	private AuthProvider saveOrUpdate(String registrationId, OAuthAttributes attributes) {
 		Long externalProviderId = Long.valueOf(attributes.getAttributes().get("id").toString());
 		AuthProvider authProvider = authProviderRepository.findByAuthProviderAndExternalProviderId(registrationId,

--- a/dongmanee/src/main/resources/application-dev.yaml
+++ b/dongmanee/src/main/resources/application-dev.yaml
@@ -1,4 +1,4 @@
 jwt:
   secret: "a335dd7d3892cb7239cf34803afb9fb89719ec136a36f029d802841aaa9893db"
-  access-token-validity-in-seconds: 60
+  access-token-validity-in-seconds: 3600
   refresh-token-validity-in-seconds: 2592000


### PR DESCRIPTION
# What is this PR
- SecurityContext에 인증 객체가 들어가도록 처리
  - Barer 방식으로 헤더에 토큰을 넣으면 자동으로처리
  - 처리 이후 `@AuthenticationPrincipal`을 이용하여 UserDetails를 가져올수 있다. 이를 서비스에서 Member로 변경하여 사용
- 예외 처리 추가
  - 잘못된 JWT 서명입니다
  - 만료된 JWT 토큰입니다.
  - 지원되지 않는 JWT 토큰입니다.
  - JWT 토큰이 잘못되었습니다.