### PR TITLE
55 feat club main page info

### DIFF
--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/ClubController.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/ClubController.java
@@ -1,17 +1,30 @@
 package com.dongmanee.domain.club.controller;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dongmanee.domain.club.controller.apidoc.ClubControllerApiDocs;
 import com.dongmanee.domain.club.controller.mapper.ClubMapper;
 import com.dongmanee.domain.club.domain.Club;
+import com.dongmanee.domain.club.dto.request.PostSearchingInfo;
 import com.dongmanee.domain.club.dto.request.RequestCreateClub;
+import com.dongmanee.domain.club.dto.response.postsearch.PostSearchResponse;
+import com.dongmanee.domain.club.enums.PostCategory;
 import com.dongmanee.domain.club.service.ClubService;
+import com.dongmanee.domain.club.service.PostPagingService;
 import com.dongmanee.domain.member.domain.Member;
 import com.dongmanee.domain.member.service.MemberService;
+import com.dongmanee.domain.post.domain.Post;
 import com.dongmanee.domain.security.domain.CustomUserDetails;
 import com.dongmanee.global.utils.ApiResult;
 
@@ -23,20 +36,36 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "클럽", description = "클럽 API 명세서")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/clubs")
 @Slf4j
 public class ClubController implements ClubControllerApiDocs {
 	private final ClubMapper clubMapper;
 	private final ClubService clubService;
 	private final MemberService memberService;
+	private final PostPagingService postPagingService;
 
 	//TODO: 클럽 정보 가져오는 URL 리턴으로 변경
-	@PostMapping("/clubs")
+	@PostMapping
 	public ApiResult<?> createClub(@Valid @RequestBody RequestCreateClub createClub,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Member requestMember = memberService.findById(Long.parseLong(userDetails.getUsername()));
 		Club club = clubMapper.toEntity(createClub, clubService);
 		clubService.createClub(club, requestMember);
 		return ApiResult.isCreated("클럽이 생성되었습니다.");
+	}
+
+	//TODO: 현재 Like, Comment 미구현으로 인해 null 값 반환
+	@GetMapping("/{club-id}/posts")
+	public ApiResult<List<PostSearchResponse>> getClubNotify(
+		@PathVariable("club-id") Long requestClubId, @RequestParam(name = "category") PostCategory category,
+		@RequestParam("latest-post-time") LocalDateTime cursor, @RequestParam("size") Integer pageSize) {
+		PostSearchingInfo postSearchingRequestDto = clubMapper.toDto(requestClubId, category, cursor, pageSize);
+		List<Post> posts = postPagingService.pagingDivider(postSearchingRequestDto);
+		List<PostSearchResponse> collect = posts.stream()
+			.map(clubMapper::postListToResponse)
+			.collect(Collectors.toList());
+
+		return ApiResult.isOk(collect, "조회에 성공하였습니다");
 	}
 
 	// TODO 1. 클럽 가입 요청 기능 추가

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/ClubController.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/ClubController.java
@@ -1,6 +1,5 @@
 package com.dongmanee.domain.club.controller;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -58,7 +57,7 @@ public class ClubController implements ClubControllerApiDocs {
 	@GetMapping("/{club-id}/posts")
 	public ApiResult<List<PostSearchResponse>> getClubNotify(
 		@PathVariable("club-id") Long requestClubId, @RequestParam(name = "category") PostCategory category,
-		@RequestParam("latest-post-time") LocalDateTime cursor, @RequestParam("size") Integer pageSize) {
+		@RequestParam(value = "oldest-post-id", required = false) Long cursor, @RequestParam("size") Integer pageSize) {
 		PostSearchingInfo postSearchingRequestDto = clubMapper.toDto(requestClubId, category, cursor, pageSize);
 		List<Post> posts = postPagingService.pagingDivider(postSearchingRequestDto);
 		List<PostSearchResponse> collect = posts.stream()

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
@@ -60,7 +60,7 @@ public interface ClubControllerApiDocs {
 
 	@Operation(summary = "포스트 조회 요청", description = "특정 클럽의 포스트를 타입별로 조회 <br>"
 		+ "타입은 MAIN_PAGE(메인 공지사항),ALL(전체),ANNOUNCEMENT(공지사항),FREE(자유),QUESTION(문의사항) 중으로 전송<br>"
-		+ "최초 조회시 시간은 서비스 시작 이전 시간으로 조회(약 2020년 언저리면 충분)<br>"
+		+ "최초 조회시 시간은 현재 시간으로 조회<br>"
 		+ "이후 조회시 가장 마지막으로 받은 post의 created_at 값을 넣어서 보내면 그 이후 데이터 전송<br>"
 		+ "현재 Like, Comment 미구현으로 인해 null 값 반환<br>"
 		+ "data에 배열 형식으로 데이터 반환<br>"

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
@@ -60,8 +60,8 @@ public interface ClubControllerApiDocs {
 
 	@Operation(summary = "포스트 조회 요청", description = "특정 클럽의 포스트를 타입별로 조회 <br>"
 		+ "타입은 MAIN_PAGE(메인 공지사항),ALL(전체),ANNOUNCEMENT(공지사항),FREE(자유),QUESTION(문의사항) 중으로 전송<br>"
-		+ "최초 조회시 시간은 현재 시간으로 조회<br>"
-		+ "이후 조회시 가장 마지막으로 받은 post의 created_at 값을 넣어서 보내면 그 이후 데이터 전송<br>"
+		+ "최초 조회시 oldest-post-id의 값을 넣지 않은채로 전송<br>"
+		+ "이후 조회시 가장 마지막으로 받은 post의 postId 값을 oldest-post-id에 넣어서 보내면 그 이후 데이터 전송<br>"
 		+ "현재 Like, Comment 미구현으로 인해 null 값 반환<br>"
 		+ "data에 배열 형식으로 데이터 반환<br>"
 		+ "메인 공지사항은 1개만 반환, 없으면 존재X<br>"

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
@@ -97,5 +97,5 @@ public interface ClubControllerApiDocs {
 			))
 	})
 	public ApiResult<List<PostSearchResponse>> getClubNotify(Long requestClubId, PostCategory category,
-		LocalDateTime cursor, Integer pageSize);
+		Long cursor, Integer pageSize);
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/apidoc/ClubControllerApiDocs.java
@@ -1,6 +1,11 @@
 package com.dongmanee.domain.club.controller.apidoc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import com.dongmanee.domain.club.dto.request.RequestCreateClub;
+import com.dongmanee.domain.club.dto.response.postsearch.PostSearchResponse;
+import com.dongmanee.domain.club.enums.PostCategory;
 import com.dongmanee.domain.security.domain.CustomUserDetails;
 import com.dongmanee.global.utils.ApiResult;
 
@@ -53,4 +58,44 @@ public interface ClubControllerApiDocs {
 	})
 	ApiResult<?> createClub(RequestCreateClub createClub, CustomUserDetails userDetails);
 
+	@Operation(summary = "포스트 조회 요청", description = "특정 클럽의 포스트를 타입별로 조회 <br>"
+		+ "타입은 MAIN_PAGE(메인 공지사항),ALL(전체),ANNOUNCEMENT(공지사항),FREE(자유),QUESTION(문의사항) 중으로 전송<br>"
+		+ "최초 조회시 시간은 서비스 시작 이전 시간으로 조회(약 2020년 언저리면 충분)<br>"
+		+ "이후 조회시 가장 마지막으로 받은 post의 created_at 값을 넣어서 보내면 그 이후 데이터 전송<br>"
+		+ "현재 Like, Comment 미구현으로 인해 null 값 반환<br>"
+		+ "data에 배열 형식으로 데이터 반환<br>"
+		+ "메인 공지사항은 1개만 반환, 없으면 존재X<br>"
+		+ "나머지는 여러개로 반환")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200",
+			description = "조회 성공",
+			content = @Content(schema = @Schema(implementation = ApiResult.class),
+				examples = @ExampleObject(name = "post 조회 성공",
+					value = """
+								{
+									"status": 200,
+									"message": "조회에 성공하였습니다",
+									"data": [
+								                     {
+								                         "postId": 1,
+								                         "postTitle": "testTitle",
+								                         "postCreatedAt": "2023-11-15T20:00:00",
+								                         "postBody": "testBody",
+								                         "postCategoryName": "test",
+								                         "postWriter": {
+								                             "writerId": 1,
+								                             "writerName": "Tester",
+								                             "writerImage": "ImageUrl"
+								                         },
+								                         "postLikesNum": 현재 미구현,
+								                         "postCommentNum": 현재 미구현,
+								                         "isLike": 현재 미구현
+								                     }
+								                 ]
+								}
+						""")
+			))
+	})
+	public ApiResult<List<PostSearchResponse>> getClubNotify(Long requestClubId, PostCategory category,
+		LocalDateTime cursor, Integer pageSize);
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/mapper/ClubMapper.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/mapper/ClubMapper.java
@@ -1,5 +1,6 @@
 package com.dongmanee.domain.club.controller.mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.mapstruct.Context;
@@ -10,10 +11,14 @@ import org.mapstruct.ReportingPolicy;
 
 import com.dongmanee.domain.club.domain.Club;
 import com.dongmanee.domain.club.domain.ClubCategory;
+import com.dongmanee.domain.club.dto.request.PostSearchingInfo;
 import com.dongmanee.domain.club.dto.request.RequestCreateClub;
 import com.dongmanee.domain.club.dto.request.RequestEditClubDescriptionAndAddress;
+import com.dongmanee.domain.club.dto.response.postsearch.PostSearchResponse;
+import com.dongmanee.domain.club.enums.PostCategory;
 import com.dongmanee.domain.club.service.ClubService;
 import com.dongmanee.domain.member.dto.response.MainPageMemberClubDto;
+import com.dongmanee.domain.post.domain.Post;
 
 @Mapper(componentModel = "spring",
 	unmappedTargetPolicy = ReportingPolicy.IGNORE,
@@ -24,6 +29,18 @@ public interface ClubMapper {
 		@Context ClubService clubService);
 
 	Club toEntity(Long id, RequestEditClubDescriptionAndAddress dto);
+
+	PostSearchingInfo toDto(Long clubId, PostCategory postCategory, LocalDateTime cursor, Integer pageSize);
+
+	@Mapping(source = "id", target = "postId")
+	@Mapping(source = "title", target = "postTitle")
+	@Mapping(source = "createdAt", target = "postCreatedAt")
+	@Mapping(source = "body", target = "postBody")
+	@Mapping(source = "category.name", target = "postCategoryName")
+	@Mapping(source = "member.id", target = "postWriter.writerId")
+	@Mapping(source = "member.name", target = "postWriter.writerName")
+	@Mapping(source = "member.profileImageUrl", target = "postWriter.writerImage")
+	PostSearchResponse postListToResponse(Post post);
 
 	List<MainPageMemberClubDto> toMemberJoinedClubResponseDto(List<Club> clubs);
 

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/controller/mapper/ClubMapper.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/controller/mapper/ClubMapper.java
@@ -30,7 +30,7 @@ public interface ClubMapper {
 
 	Club toEntity(Long id, RequestEditClubDescriptionAndAddress dto);
 
-	PostSearchingInfo toDto(Long clubId, PostCategory postCategory, LocalDateTime cursor, Integer pageSize);
+	PostSearchingInfo toDto(Long clubId, PostCategory postCategory, Long cursor, Integer pageSize);
 
 	@Mapping(source = "id", target = "postId")
 	@Mapping(source = "title", target = "postTitle")

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/dto/request/PostSearchingInfo.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/dto/request/PostSearchingInfo.java
@@ -1,6 +1,5 @@
 package com.dongmanee.domain.club.dto.request;
 
-import java.time.LocalDateTime;
 
 import com.dongmanee.domain.club.enums.PostCategory;
 
@@ -18,6 +17,6 @@ import lombok.Setter;
 public class PostSearchingInfo {
 	private Long clubId;
 	private PostCategory postCategory;
-	private LocalDateTime cursor;
+	private Long cursor;
 	private Integer pageSize;
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/dto/request/PostSearchingInfo.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/dto/request/PostSearchingInfo.java
@@ -1,0 +1,23 @@
+package com.dongmanee.domain.club.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.dongmanee.domain.club.enums.PostCategory;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSearchingInfo {
+	private Long clubId;
+	private PostCategory postCategory;
+	private LocalDateTime cursor;
+	private Integer pageSize;
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/dto/response/postsearch/PostSearchResponse.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/dto/response/postsearch/PostSearchResponse.java
@@ -20,6 +20,7 @@ public class PostSearchResponse {
 	private String postBody;
 	private String postCategoryName;
 	private PostWriter postWriter;
+	// TODO: 아래 Like, Comment 부분은 기능 생성 이후 매퍼에서 기능 구현 변경
 	private Long postLikesNum;
 	private Long postCommentNum;
 	private Boolean isLike;

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/dto/response/postsearch/PostSearchResponse.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/dto/response/postsearch/PostSearchResponse.java
@@ -1,0 +1,26 @@
+package com.dongmanee.domain.club.dto.response.postsearch;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSearchResponse {
+	private Long postId;
+	private String postTitle;
+	private LocalDateTime postCreatedAt;
+	private String postBody;
+	private String postCategoryName;
+	private PostWriter postWriter;
+	private Long postLikesNum;
+	private Long postCommentNum;
+	private Boolean isLike;
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/dto/response/postsearch/PostWriter.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/dto/response/postsearch/PostWriter.java
@@ -1,0 +1,18 @@
+package com.dongmanee.domain.club.dto.response.postsearch;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostWriter {
+	private Long writerId;
+	private String writerName;
+	private String writerImage;
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/enums/PostCategory.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/enums/PostCategory.java
@@ -1,0 +1,17 @@
+package com.dongmanee.domain.club.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostCategory {
+	MAIN_PAGE("메인 공지사항"),
+	ALL("전체"),
+	ANNOUNCEMENT("공지사항"),
+	FREE("자유"),
+	QUESTION("문의사항");
+
+	private final String value;
+
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingService.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingService.java
@@ -1,0 +1,11 @@
+package com.dongmanee.domain.club.service;
+
+import java.util.List;
+
+import com.dongmanee.domain.club.dto.request.PostSearchingInfo;
+import com.dongmanee.domain.post.domain.Post;
+
+public interface PostPagingService {
+	List<Post> pagingDivider(PostSearchingInfo request);
+
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingServiceImpl.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingServiceImpl.java
@@ -1,0 +1,65 @@
+package com.dongmanee.domain.club.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.dongmanee.domain.club.dto.request.PostSearchingInfo;
+import com.dongmanee.domain.club.enums.PostCategory;
+import com.dongmanee.domain.post.dao.PostRepository;
+import com.dongmanee.domain.post.domain.Post;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostPagingServiceImpl implements PostPagingService {
+
+	private final PostRepository postRepository;
+
+	public List<Post> pagingDivider(PostSearchingInfo request) {
+		switch (request.getPostCategory()) {
+			case MAIN_PAGE -> {
+				return singleAnnouncement(request.getClubId());
+			}
+			case ALL -> {
+				return everyPageContent(request.getClubId(), request.getCursor(), request.getPageSize());
+			}
+			case ANNOUNCEMENT, QUESTION -> {
+				return specificCategoryPageContent(request.getClubId(), request.getCursor(), request.getPageSize(),
+					request.getPostCategory());
+			}
+			case FREE -> {
+				return nonCategorizedPageContent(request.getClubId(), request.getCursor(), request.getPageSize());
+			}
+		}
+		return new ArrayList<>();
+	}
+
+	private List<Post> singleAnnouncement(Long clubId) {
+		Pageable pageable = PageRequest.of(0, 1, Sort.by("createdAt").descending());
+		return postRepository.findLatestPostByClubId(clubId, pageable);
+	}
+
+	private List<Post> everyPageContent(Long clubId, LocalDateTime cursor, Integer pageSize) {
+		Pageable pageable = PageRequest.of(0, pageSize);
+		return postRepository.findEveryPostsAfterCursor(clubId, cursor, pageable);
+	}
+
+	private List<Post> specificCategoryPageContent(Long clubId, LocalDateTime cursor, Integer pageSize,
+		PostCategory postCategory) {
+		Pageable pageable = PageRequest.of(0, pageSize);
+		return postRepository.findSpecificPostsAfterCursor(clubId, postCategory.getValue(), cursor, pageable);
+	}
+
+	private List<Post> nonCategorizedPageContent(Long clubId, LocalDateTime cursor, Integer pageSize) {
+		Pageable pageable = PageRequest.of(0, pageSize);
+		return postRepository.findWithoutSpecificPostsAfterCursor(clubId, cursor, pageable);
+	}
+
+}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingServiceImpl.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingServiceImpl.java
@@ -1,6 +1,5 @@
 package com.dongmanee.domain.club.service;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,24 +39,24 @@ public class PostPagingServiceImpl implements PostPagingService {
 		}
 		return new ArrayList<>();
 	}
-
+	//TODO: 매서드명 변경
 	private List<Post> singleAnnouncement(Long clubId) {
 		Pageable pageable = PageRequest.of(0, 1, Sort.by("createdAt").descending());
 		return postRepository.findLatestPostByClubId(clubId, pageable);
 	}
 
-	private List<Post> everyPageContent(Long clubId, LocalDateTime cursor, Integer pageSize) {
+	private List<Post> everyPageContent(Long clubId, Long cursor, Integer pageSize) {
 		Pageable pageable = PageRequest.of(0, pageSize);
 		return postRepository.findEveryPostsAfterCursor(clubId, cursor, pageable);
 	}
 
-	private List<Post> specificCategoryPageContent(Long clubId, LocalDateTime cursor, Integer pageSize,
+	private List<Post> specificCategoryPageContent(Long clubId, Long cursor, Integer pageSize,
 		PostCategory postCategory) {
 		Pageable pageable = PageRequest.of(0, pageSize);
 		return postRepository.findSpecificPostsAfterCursor(clubId, postCategory.getValue(), cursor, pageable);
 	}
 
-	private List<Post> nonCategorizedPageContent(Long clubId, LocalDateTime cursor, Integer pageSize) {
+	private List<Post> nonCategorizedPageContent(Long clubId, Long cursor, Integer pageSize) {
 		Pageable pageable = PageRequest.of(0, pageSize);
 		return postRepository.findWithoutSpecificPostsAfterCursor(clubId, cursor, pageable);
 	}

--- a/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingServiceImpl.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/club/service/PostPagingServiceImpl.java
@@ -24,39 +24,39 @@ public class PostPagingServiceImpl implements PostPagingService {
 	public List<Post> pagingDivider(PostSearchingInfo request) {
 		switch (request.getPostCategory()) {
 			case MAIN_PAGE -> {
-				return singleAnnouncement(request.getClubId());
+				return findAnnouncement(request.getClubId());
 			}
 			case ALL -> {
-				return everyPageContent(request.getClubId(), request.getCursor(), request.getPageSize());
+				return findPosts(request.getClubId(), request.getCursor(), request.getPageSize());
 			}
 			case ANNOUNCEMENT, QUESTION -> {
-				return specificCategoryPageContent(request.getClubId(), request.getCursor(), request.getPageSize(),
+				return findPostsWithCategory(request.getClubId(), request.getCursor(), request.getPageSize(),
 					request.getPostCategory());
 			}
 			case FREE -> {
-				return nonCategorizedPageContent(request.getClubId(), request.getCursor(), request.getPageSize());
+				return findFreeCategoryPosts(request.getClubId(), request.getCursor(), request.getPageSize());
 			}
 		}
 		return new ArrayList<>();
 	}
-	//TODO: 매서드명 변경
-	private List<Post> singleAnnouncement(Long clubId) {
+
+	private List<Post> findAnnouncement(Long clubId) {
 		Pageable pageable = PageRequest.of(0, 1, Sort.by("createdAt").descending());
-		return postRepository.findLatestPostByClubId(clubId, pageable);
+		return postRepository.findAnnouncementPostByClubId(clubId, pageable);
 	}
 
-	private List<Post> everyPageContent(Long clubId, Long cursor, Integer pageSize) {
+	private List<Post> findPosts(Long clubId, Long cursor, Integer pageSize) {
 		Pageable pageable = PageRequest.of(0, pageSize);
 		return postRepository.findEveryPostsAfterCursor(clubId, cursor, pageable);
 	}
 
-	private List<Post> specificCategoryPageContent(Long clubId, Long cursor, Integer pageSize,
+	private List<Post> findPostsWithCategory(Long clubId, Long cursor, Integer pageSize,
 		PostCategory postCategory) {
 		Pageable pageable = PageRequest.of(0, pageSize);
 		return postRepository.findSpecificPostsAfterCursor(clubId, postCategory.getValue(), cursor, pageable);
 	}
 
-	private List<Post> nonCategorizedPageContent(Long clubId, Long cursor, Integer pageSize) {
+	private List<Post> findFreeCategoryPosts(Long clubId, Long cursor, Integer pageSize) {
 		Pageable pageable = PageRequest.of(0, pageSize);
 		return postRepository.findWithoutSpecificPostsAfterCursor(clubId, cursor, pageable);
 	}

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/PostRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/PostRepository.java
@@ -14,5 +14,5 @@ public interface PostRepository {
 
 	List<Post> findWithoutSpecificPostsAfterCursor(Long clubId, Long cursor, Pageable pageable);
 
-	List<Post> findLatestPostByClubId(Long clubId, Pageable pageable);
+	List<Post> findAnnouncementPostByClubId(Long clubId, Pageable pageable);
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/PostRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/PostRepository.java
@@ -1,4 +1,19 @@
 package com.dongmanee.domain.post.dao;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.dongmanee.domain.post.domain.Post;
+
 public interface PostRepository {
+
+	List<Post> findEveryPostsAfterCursor(Long clubId, LocalDateTime cursor, Pageable pageable);
+
+	List<Post> findSpecificPostsAfterCursor(Long clubId, String category, LocalDateTime cursor, Pageable pageable);
+
+	List<Post> findWithoutSpecificPostsAfterCursor(Long clubId, LocalDateTime cursor, Pageable pageable);
+
+	List<Post> findLatestPostByClubId(Long clubId, Pageable pageable);
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/PostRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/PostRepository.java
@@ -1,6 +1,5 @@
 package com.dongmanee.domain.post.dao;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -9,11 +8,11 @@ import com.dongmanee.domain.post.domain.Post;
 
 public interface PostRepository {
 
-	List<Post> findEveryPostsAfterCursor(Long clubId, LocalDateTime cursor, Pageable pageable);
+	List<Post> findEveryPostsAfterCursor(Long clubId, Long cursor, Pageable pageable);
 
-	List<Post> findSpecificPostsAfterCursor(Long clubId, String category, LocalDateTime cursor, Pageable pageable);
+	List<Post> findSpecificPostsAfterCursor(Long clubId, String category, Long cursor, Pageable pageable);
 
-	List<Post> findWithoutSpecificPostsAfterCursor(Long clubId, LocalDateTime cursor, Pageable pageable);
+	List<Post> findWithoutSpecificPostsAfterCursor(Long clubId, Long cursor, Pageable pageable);
 
 	List<Post> findLatestPostByClubId(Long clubId, Pageable pageable);
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -14,19 +14,29 @@ import com.dongmanee.domain.post.domain.Post;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long>, PostRepository {
 
-	@Query("SELECT p FROM Post p LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member WHERE p.club.id = :clubId AND p.createdAt > :cursor ORDER BY p.createdAt ASC")
+	@Query("SELECT p FROM Post p LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.club.id = :clubId AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
 	List<Post> findEveryPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor, Pageable pageable);
 
-	@Query("SELECT p FROM Post p WHERE p.category.name = :category AND p.club.id = :clubId AND p.createdAt > :cursor ORDER BY p.createdAt ASC")
+	@Query("SELECT p FROM Post p "
+		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.category.name = :category AND p.club.id = :clubId AND p.createdAt > :cursor "
+		+ "ORDER BY p.createdAt DESC")
 	List<Post> findSpecificPostsAfterCursor(@Param("clubId") Long clubId, @Param("category") String category,
 		LocalDateTime cursor,
 		Pageable pageable);
 
-	@Query("SELECT p FROM Post p WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND p.club.id = :clubId AND p.createdAt > :cursor ORDER BY p.createdAt ASC")
+	@Query("SELECT p FROM Post p "
+		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND "
+		+ "p.club.id = :clubId AND p.createdAt > :cursor "
+		+ "ORDER BY p.createdAt DESC")
 	List<Post> findWithoutSpecificPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor,
 		Pageable pageable);
 
-	@Query("SELECT p FROM Post p WHERE p.club.id = :clubId ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM Post p "
+		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.club.id = :clubId ORDER BY p.createdAt DESC")
 	Page<Post> findPostsByClubId(Long clubId, Pageable pageable);
 
 	default List<Post> findLatestPostByClubId(Long clubId, Pageable pageable) {

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -35,11 +35,11 @@ public interface PostJpaRepository extends JpaRepository<Post, Long>, PostReposi
 
 	@Query("SELECT DISTINCT p FROM Post p "
 		+ "LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.member "
-		+ "WHERE p.category.club.id = :clubId ORDER BY p.createdAt DESC")
-	Page<Post> findPostsByClubId(Long clubId, Pageable pageable);
+		+ "WHERE p.category.club.id = :clubId AND p.category.name = '공지사항' ORDER BY p.createdAt DESC")
+	Page<Post> findAnnouncementPostsByClubId(Long clubId, Pageable pageable);
 
-	default List<Post> findLatestPostByClubId(Long clubId, Pageable pageable) {
-		return findPostsByClubId(clubId, pageable)
+	default List<Post> findAnnouncementPostByClubId(Long clubId, Pageable pageable) {
+		return findAnnouncementPostsByClubId(clubId, pageable)
 			.stream()
 			.toList();
 	}

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -20,7 +20,7 @@ public interface PostJpaRepository extends JpaRepository<Post, Long>, PostReposi
 
 	@Query("SELECT p FROM Post p "
 		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
-		+ "WHERE p.category.name = :category AND p.club.id = :clubId AND p.createdAt > :cursor "
+		+ "WHERE p.category.name = :category AND p.club.id = :clubId AND p.createdAt < :cursor "
 		+ "ORDER BY p.createdAt DESC")
 	List<Post> findSpecificPostsAfterCursor(@Param("clubId") Long clubId, @Param("category") String category,
 		LocalDateTime cursor,
@@ -29,7 +29,7 @@ public interface PostJpaRepository extends JpaRepository<Post, Long>, PostReposi
 	@Query("SELECT p FROM Post p "
 		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND "
-		+ "p.club.id = :clubId AND p.createdAt > :cursor "
+		+ "p.club.id = :clubId AND p.createdAt < :cursor "
 		+ "ORDER BY p.createdAt DESC")
 	List<Post> findWithoutSpecificPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor,
 		Pageable pageable);

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -1,6 +1,5 @@
 package com.dongmanee.domain.post.dao.jpa;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -15,22 +14,23 @@ import com.dongmanee.domain.post.domain.Post;
 public interface PostJpaRepository extends JpaRepository<Post, Long>, PostRepository {
 
 	@Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.member "
-		+ "WHERE p.category.club.id = :clubId AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
-	List<Post> findEveryPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor, Pageable pageable);
+		+ "WHERE p.category.club.id = :clubId AND (:cursor IS NULL OR p.id < :cursor) ORDER BY p.createdAt DESC")
+	List<Post> findEveryPostsAfterCursor(@Param("clubId") Long clubId, @Param("cursor") Long cursor, Pageable pageable);
 
 	@Query("SELECT p FROM Post p "
 		+ "LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club  LEFT JOIN FETCH p.member "
-		+ "WHERE p.category.name = :category AND p.category.club.id = :clubId AND p.createdAt < :cursor "
+		+ "WHERE p.category.name = :category AND p.category.club.id = :clubId "
+		+ "AND (:cursor IS NULL OR p.id < :cursor) "
 		+ "ORDER BY p.createdAt DESC")
 	List<Post> findSpecificPostsAfterCursor(@Param("clubId") Long clubId, @Param("category") String category,
-		@Param("cursor") LocalDateTime cursor, Pageable pageable);
+		@Param("cursor") Long cursor, Pageable pageable);
 
 	@Query("SELECT DISTINCT p FROM Post p "
 		+ "LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND "
-		+ "p.category.club.id = :clubId AND p.createdAt < :cursor "
+		+ "p.category.club.id = :clubId AND (:cursor IS NULL OR p.id < :cursor) "
 		+ "ORDER BY p.createdAt DESC")
-	List<Post> findWithoutSpecificPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor,
+	List<Post> findWithoutSpecificPostsAfterCursor(@Param("clubId") Long clubId, Long cursor,
 		Pageable pageable);
 
 	@Query("SELECT DISTINCT p FROM Post p "

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -14,29 +14,29 @@ import com.dongmanee.domain.post.domain.Post;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long>, PostRepository {
 
-	@Query("SELECT p FROM Post p LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
-		+ "WHERE p.club.id = :clubId AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
+	@Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.category.club.id = :clubId AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
 	List<Post> findEveryPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor, Pageable pageable);
 
-	@Query("SELECT p FROM Post p "
-		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
-		+ "WHERE p.category.name = :category AND p.club.id = :clubId AND p.createdAt < :cursor "
+	@Query("SELECT DISTINCT p FROM Post p "
+		+ "LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.category.name = :category AND p.category.club.id = :clubId AND p.createdAt < :cursor "
 		+ "ORDER BY p.createdAt DESC")
 	List<Post> findSpecificPostsAfterCursor(@Param("clubId") Long clubId, @Param("category") String category,
 		LocalDateTime cursor,
 		Pageable pageable);
 
-	@Query("SELECT p FROM Post p "
-		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+	@Query("SELECT DISTINCT p FROM Post p "
+		+ "LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND "
-		+ "p.club.id = :clubId AND p.createdAt < :cursor "
+		+ "p.category.club.id = :clubId AND p.createdAt < :cursor "
 		+ "ORDER BY p.createdAt DESC")
 	List<Post> findWithoutSpecificPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor,
 		Pageable pageable);
 
-	@Query("SELECT p FROM Post p "
-		+ "LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
-		+ "WHERE p.club.id = :clubId ORDER BY p.createdAt DESC")
+	@Query("SELECT DISTINCT p FROM Post p "
+		+ "LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "WHERE p.category.club.id = :clubId ORDER BY p.createdAt DESC")
 	Page<Post> findPostsByClubId(Long clubId, Pageable pageable);
 
 	default List<Post> findLatestPostByClubId(Long clubId, Pageable pageable) {

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -1,9 +1,37 @@
 package com.dongmanee.domain.post.dao.jpa;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.dongmanee.domain.post.dao.PostRepository;
 import com.dongmanee.domain.post.domain.Post;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long>, PostRepository {
+
+	@Query("SELECT p FROM Post p LEFT JOIN FETCH p.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member WHERE p.club.id = :clubId AND p.createdAt > :cursor ORDER BY p.createdAt ASC")
+	List<Post> findEveryPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor, Pageable pageable);
+
+	@Query("SELECT p FROM Post p WHERE p.category.name = :category AND p.club.id = :clubId AND p.createdAt > :cursor ORDER BY p.createdAt ASC")
+	List<Post> findSpecificPostsAfterCursor(@Param("clubId") Long clubId, @Param("category") String category,
+		LocalDateTime cursor,
+		Pageable pageable);
+
+	@Query("SELECT p FROM Post p WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND p.club.id = :clubId AND p.createdAt > :cursor ORDER BY p.createdAt ASC")
+	List<Post> findWithoutSpecificPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor,
+		Pageable pageable);
+
+	@Query("SELECT p FROM Post p WHERE p.club.id = :clubId ORDER BY p.createdAt DESC")
+	Page<Post> findPostsByClubId(Long clubId, Pageable pageable);
+
+	default List<Post> findLatestPostByClubId(Long clubId, Pageable pageable) {
+		return findPostsByClubId(clubId, pageable)
+			.stream()
+			.toList();
+	}
 }

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/dao/jpa/PostJpaRepository.java
@@ -14,20 +14,19 @@ import com.dongmanee.domain.post.domain.Post;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long>, PostRepository {
 
-	@Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+	@Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.club.id = :clubId AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
 	List<Post> findEveryPostsAfterCursor(@Param("clubId") Long clubId, LocalDateTime cursor, Pageable pageable);
 
-	@Query("SELECT DISTINCT p FROM Post p "
-		+ "LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+	@Query("SELECT p FROM Post p "
+		+ "LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club  LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.name = :category AND p.category.club.id = :clubId AND p.createdAt < :cursor "
 		+ "ORDER BY p.createdAt DESC")
 	List<Post> findSpecificPostsAfterCursor(@Param("clubId") Long clubId, @Param("category") String category,
-		LocalDateTime cursor,
-		Pageable pageable);
+		@Param("cursor") LocalDateTime cursor, Pageable pageable);
 
 	@Query("SELECT DISTINCT p FROM Post p "
-		+ "LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.name != '공지사항' AND p.category.name != '문의사항' AND "
 		+ "p.category.club.id = :clubId AND p.createdAt < :cursor "
 		+ "ORDER BY p.createdAt DESC")
@@ -35,7 +34,7 @@ public interface PostJpaRepository extends JpaRepository<Post, Long>, PostReposi
 		Pageable pageable);
 
 	@Query("SELECT DISTINCT p FROM Post p "
-		+ "LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.category LEFT JOIN FETCH p.member "
+		+ "LEFT JOIN FETCH p.category LEFT JOIN FETCH p.category.club LEFT JOIN FETCH p.member "
 		+ "WHERE p.category.club.id = :clubId ORDER BY p.createdAt DESC")
 	Page<Post> findPostsByClubId(Long clubId, Pageable pageable);
 

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/domain/Post.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/domain/Post.java
@@ -33,6 +33,10 @@ public class Post extends BaseEntity {
 	private Club club;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id")
+	private PostCategory category;
+
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
 

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/domain/Post.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/domain/Post.java
@@ -1,6 +1,5 @@
 package com.dongmanee.domain.post.domain;
 
-import com.dongmanee.domain.club.domain.Club;
 import com.dongmanee.domain.member.domain.Member;
 import com.dongmanee.global.entity.BaseEntity;
 
@@ -27,10 +26,6 @@ public class Post extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "club_id")
-	private Club club;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_id")

--- a/dongmanee/src/main/java/com/dongmanee/domain/post/domain/PostCategory.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/post/domain/PostCategory.java
@@ -1,5 +1,7 @@
 package com.dongmanee.domain.post.domain;
 
+import java.util.List;
+
 import com.dongmanee.domain.club.domain.Club;
 import com.dongmanee.global.entity.BaseEntity;
 
@@ -10,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +33,9 @@ public class PostCategory extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "club_id")
 	private Club club;
+
+	@OneToMany(mappedBy = "category")
+	private List<Post> posts;
 
 	private String name;
 	private Boolean isPublic;

--- a/dongmanee/src/main/java/com/dongmanee/domain/security/config/SecurityConfig.java
+++ b/dongmanee/src/main/java/com/dongmanee/domain/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.dongmanee.domain.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -56,6 +57,8 @@ public class SecurityConfig implements WebMvcConfigurer {
 			// HTTP 요청에 대한 인가 설정
 			.authorizeHttpRequests(
 				authorizedRequests -> authorizedRequests
+					.requestMatchers(new AntPathRequestMatcher("/clubs/**", HttpMethod.GET.name()))
+					.permitAll()
 					.requestMatchers(new AntPathRequestMatcher("/login"))
 					.permitAll() // 모든 요청에 대해서 인증 없이 허용
 					.requestMatchers(new AntPathRequestMatcher("/oauth2/**"))
@@ -81,6 +84,7 @@ public class SecurityConfig implements WebMvcConfigurer {
 			.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
 			.addFilterAfter(clubUserAuthenticationFilter, JwtAuthenticationFilter.class);
+
 		return http.build();
 	}
 

--- a/dongmanee/src/main/resources/import.sql
+++ b/dongmanee/src/main/resources/import.sql
@@ -24,12 +24,12 @@ INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at)
 INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at) VALUES (true, 1, '문의사항', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
 
 -- post 더미 데이터
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 2, 1, '2023-11-15 10:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle1');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 2, 1, '2023-11-15 11:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle2');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 2, 1, '2023-11-15 12:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle3');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 3, 1, '2023-11-15 13:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle4');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 3, 1, '2023-11-15 14:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle5');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 3, 1, '2023-11-15 15:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle6');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 16:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle7');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 17:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle8');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 18:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle9');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 2, '2023-11-15 10:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle1');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 2, '2023-11-15 11:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle2');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 2, '2023-11-15 12:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle3');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 3, '2023-11-15 13:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle4');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 3, '2023-11-15 14:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle5');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 3, '2023-11-15 15:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle6');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 1, '2023-11-15 16:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle7');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 1, '2023-11-15 17:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle8');
+INSERT INTO club_post (is_deleted, category_id, created_at, member_id, update_at, body, title) VALUES (false, 1, '2023-11-15 18:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle9');

--- a/dongmanee/src/main/resources/import.sql
+++ b/dongmanee/src/main/resources/import.sql
@@ -20,14 +20,16 @@ INSERT INTO club_user (member_id, club_id, club_role, created_at, update_at) VAL
 
 -- club_post_category
 INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at) VALUES (true, 1, 'test', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
+INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at) VALUES (true, 1, '공지사항', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
+INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at) VALUES (true, 1, '문의사항', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
 
 -- post 더미 데이터
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 10:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle1');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 11:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle2');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 12:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle3');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 13:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle4');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 14:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle5');
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 15:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle6');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 2, 1, '2023-11-15 10:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle1');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 2, 1, '2023-11-15 11:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle2');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 2, 1, '2023-11-15 12:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle3');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 3, 1, '2023-11-15 13:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle4');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 3, 1, '2023-11-15 14:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle5');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 3, 1, '2023-11-15 15:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle6');
 INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 16:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle7');
 INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 17:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle8');
 INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 18:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle9');

--- a/dongmanee/src/main/resources/import.sql
+++ b/dongmanee/src/main/resources/import.sql
@@ -22,4 +22,12 @@ INSERT INTO club_user (member_id, club_id, club_role, created_at, update_at) VAL
 INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at) VALUES (true, 1, 'test', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
 
 -- post 더미 데이터
-INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 20:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 10:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle1');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 11:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle2');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 12:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle3');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 13:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle4');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 14:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle5');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 15:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle6');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 16:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle7');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 17:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle8');
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 18:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle9');

--- a/dongmanee/src/main/resources/import.sql
+++ b/dongmanee/src/main/resources/import.sql
@@ -5,9 +5,21 @@ INSERT INTO university (name, created_at, update_at) VALUES ('충남대학교', 
 INSERT INTO university (name, created_at, update_at) VALUES ('우송대학교', '2023-11-15 19:59:00', '2023-11-15 19:59:00');
 INSERT INTO university (name, created_at, update_at) VALUES ('대전대학교', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
 
--- user 더미 데이터
-INSERT INTO member (university_id, role, student_id, department, name, phone, email, password, birth, created_at, update_at) VALUES (1, 'ROLE_USER', '12345678','testDepartment','Tester','010-1234-5678','test@gmail.com','$2a$10$EBS76qlSxOQkuOyIBaoSruBIeu64i1hU/n9AsRUaPTXt//QaEsErS','1999-01-01','2023-11-15 20:00:00', '2023-11-15 20:00:00');
-
 -- club_category 더미 데이터
 INSERT INTO club_category (name, created_at, update_at) VALUES ('category1', '2023-11-15 19:59:00', '2023-11-15 19:59:00');
 INSERT INTO club_category (name, created_at, update_at) VALUES ('category2', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
+
+-- user 더미 데이터
+INSERT INTO member (university_id, role, student_id, department, name, phone, email, password, birth, created_at, update_at) VALUES (1, 'ROLE_USER', '12345678','testDepartment','Tester','010-1234-5678','test@gmail.com','$2a$10$EBS76qlSxOQkuOyIBaoSruBIeu64i1hU/n9AsRUaPTXt//QaEsErS','1999-01-01','2023-11-15 20:00:00', '2023-11-15 20:00:00');
+
+-- club 더미 데이터
+INSERT INTO club (university_id, category_id, name, is_deleted, created_at, update_at) VALUES (1, 1, 'testClub', false, '2023-11-15 20:00:00', '2023-11-15 20:00:00');
+
+-- club_user 더미 데이터
+INSERT INTO club_user (member_id, club_id, club_role, created_at, update_at) VALUES (1, 1, 'HOST', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
+
+-- club_post_category
+INSERT INTO club_post_category (is_public, club_id, name, created_at, update_at) VALUES (true, 1, 'test', '2023-11-15 20:00:00', '2023-11-15 20:00:00');
+
+-- post 더미 데이터
+INSERT INTO club_post (is_deleted, category_id, club_id, created_at, member_id, update_at, body, title) VALUES (false, 1, 1, '2023-11-15 20:00:00', 1, '2023-11-15 20:00:00', 'testBody', 'testTitle');


### PR DESCRIPTION
# Explain About PR
## Issue With
 - #55 

## Explain
동만이 페이지 중 클럽에 특정 포스트를 조회하기 위한 기능 추가

/clubs/{club-id}/posts 로 온 요청에 대해 처리

특정 클럽의 포스트를 타입별로 조회
타입은 
- MAIN_PAGE(메인 공지사항)
- ALL(전체)
- ANNOUNCEMENT(공지사항)
- FREE(자유)
- QUESTION(문의사항)

중으로 전송

최초 조회시 시간은 현재 시간으로 조회
이후 조회시 가장 마지막으로 받은 post의 created_at 값을 넣어서 보내면 그 이후 데이터 전송
현재 Like, Comment 미구현으로 인해 null 값 반환
data에 배열 형식으로 데이터 반환
메인 공지사항은 1개만 반환, 없으면 존재 빈 배열 존재
나머지는 여러개로 반환

----------------

## Addtional Explain

1. erd간 순환참조가 일어나는 부분 해결